### PR TITLE
Use object-fit:contain to maintain thumbnail aspect ratio

### DIFF
--- a/content-scripts/bookmark-dial.css
+++ b/content-scripts/bookmark-dial.css
@@ -71,6 +71,7 @@ span {
 img {
     height: 100%;
     width: 100%;
+    object-fit: contain;
 }
 img[src=""] {
     display: none;
@@ -106,5 +107,5 @@ li:hover .delete {
 .keepAspectRatio:before {
     content: "";
     display: block;
-    padding-top: calc(100% / 3 * 2);
+    padding-top: calc(100% / 3 * 2 * 1.05);
 }


### PR DESCRIPTION
Currently, thumbnails that aren't the same aspect ratio as the `<img>` will have their ratio warped to fit the img element. `Object-fit:contain` will stretch the object to fit the img box, but maintain the aspect ratio.

Additionally, the aspect ratio of the img boxes currently aren't 3:2 because of the different "`top/bottom`" and "`left/right`" values. Compensate for this in by adding "`* 1.05`" padding-top in parent element.